### PR TITLE
Add backend API endpoints for health monitoring, version information, and prediction functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.env
+.venv
+venv/
+ENV/
+.mypy_cache/
+
+# Flask
+instance/
+.webassets-cache
+flask_session/
+
+# JavaScript/Frontend
+node_modules/
+npm-debug.log
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.npm
+.yarn
+yarn.lock
+package-lock.json
+.DS_Store
+coverage/
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Build artifacts
+/static/
+/templates/static/
+/public/build/
+/build/
+
+# Environment variables
+.env
+.env.*

--- a/app-service/app.py
+++ b/app-service/app.py
@@ -1,0 +1,126 @@
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+from flasgger import Swagger
+import requests
+import json
+from config import MODEL_SERVICE_URL, APP_VERSION
+
+# Initialize Flask app
+app = Flask(__name__)
+CORS(app)  # Enable CORS for all routes
+
+# Configure Swagger documentation
+swagger_config = {
+    "headers": [],
+    "specs": [
+        {
+            "endpoint": "apispec",
+            "route": "/apispec.json",
+            "rule_filter": lambda rule: True,  # all routes
+            "model_filter": lambda tag: True,  # all models
+        }
+    ],
+    "static_url_path": "/flasgger_static",
+    "swagger_ui": True,
+    "specs_route": "/apidocs/"  # Changed from "/docs/" to "/apidocs/"
+}
+
+swagger = Swagger(app, config=swagger_config, template={
+    "info": {
+        "title": "App Service API",
+        "description": "API for the app service component",
+        "version": APP_VERSION,
+        "contact": {
+            "name": "Team 21",
+            "url": "https://github.com/remla25-team21"
+        }
+    }
+})
+
+# Dummy lib-version data (to be replaced with actual implementation)
+lib_version_info = {
+    "version": "0.1.0",
+    "name": "lib-version"
+}
+
+@app.route('/health', methods=['GET'])
+def health_check():
+    """
+    Health check endpoint
+    ---
+    responses:
+      200:
+        description: Service is healthy
+    """
+    return jsonify({"status": "ok"})
+
+@app.route('/version', methods=['GET'])
+def get_version():
+    """
+    Get app and model-service versions
+    ---
+    responses:
+      200:
+        description: Version information
+    """
+    # Try to get the model-service version
+    try:
+        model_response = requests.get(f"{MODEL_SERVICE_URL}/version", timeout=5)
+        if model_response.status_code == 200:
+            model_version = model_response.json()
+        else:
+            model_version = {"error": "Could not retrieve model service version"}
+    except requests.RequestException:
+        model_version = {"error": "Could not connect to model service"}
+    
+    return jsonify({
+        "app_version": APP_VERSION,
+        "model_service": model_version,
+        "lib_version": lib_version_info
+    })
+
+@app.route('/predict', methods=['POST'])
+def predict():
+    """
+    Make a prediction using the model-service
+    ---
+    parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          type: object
+          properties:
+            data:
+              type: string
+              description: Input data for prediction
+    responses:
+      200:
+        description: Prediction results
+      400:
+        description: Invalid input
+      500:
+        description: Error making prediction
+    """
+    if not request.is_json:
+        return jsonify({"error": "Request must be JSON"}), 400
+        
+    data = request.get_json()
+    
+    try:
+        # Forward the request to the model service
+        model_response = requests.post(
+            f"{MODEL_SERVICE_URL}/predict",
+            json=data,
+            headers={"Content-Type": "application/json"},
+            timeout=30
+        )
+        
+        return jsonify(model_response.json()), model_response.status_code
+        
+    except requests.RequestException as e:
+        return jsonify({"error": f"Error connecting to model service: {str(e)}"}), 500
+
+if __name__ == '__main__':
+    # For development only
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/app-service/app.py
+++ b/app-service/app.py
@@ -3,7 +3,7 @@ from flask_cors import CORS
 from flasgger import Swagger
 import requests
 import json
-from config import MODEL_SERVICE_URL, APP_VERSION
+from config import MODEL_SERVICE_URL, APP_VERSION  # TODO: Depends on external config module
 
 # Initialize Flask app
 app = Flask(__name__)
@@ -37,7 +37,7 @@ swagger = Swagger(app, config=swagger_config, template={
     }
 })
 
-# Dummy lib-version data (to be replaced with actual implementation)
+# TODO: Replace with actual implementation from lib-version service
 lib_version_info = {
     "version": "0.1.0",
     "name": "lib-version"
@@ -63,7 +63,7 @@ def get_version():
       200:
         description: Version information
     """
-    # Try to get the model-service version
+    # TODO: Depends on model-service being available and exposing a /version endpoint
     try:
         model_response = requests.get(f"{MODEL_SERVICE_URL}/version", timeout=5)
         if model_response.status_code == 200:
@@ -76,7 +76,7 @@ def get_version():
     return jsonify({
         "app_version": APP_VERSION,
         "model_service": model_version,
-        "lib_version": lib_version_info
+        "lib_version": lib_version_info  # TODO: Depends on lib-version implementation
     })
 
 @app.route('/predict', methods=['POST'])
@@ -107,6 +107,7 @@ def predict():
         
     data = request.get_json()
     
+    # TODO: Depends on model-service being available and exposing a /predict endpoint
     try:
         # Forward the request to the model service
         model_response = requests.post(

--- a/app-service/config.py
+++ b/app-service/config.py
@@ -1,0 +1,11 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Configuration settings
+MODEL_SERVICE_URL = os.getenv('MODEL_SERVICE_URL', 'http://localhost:5001')  # TODO: Dummy URL, replace with actual model-service URL
+APP_VERSION = os.getenv('APP_VERSION', '0.1.0')  # TODO: Dummy version, replace with actual app version
+
+# For local development you can use a .env file
+# In production, set environment variables directly

--- a/app-service/config.py
+++ b/app-service/config.py
@@ -4,7 +4,12 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Configuration settings
-MODEL_SERVICE_URL = os.getenv('MODEL_SERVICE_URL', 'http://localhost:5001')  # TODO: Dummy URL, replace with actual model-service URL
+# MODEL_SERVICE_URL: The base URL for the model service. Update this value based on the deployment environment.
+# - For local development, use a .env file to set MODEL_SERVICE_URL to the local service URL (e.g., http://localhost:5001).
+# - For staging, set the MODEL_SERVICE_URL environment variable to the staging service URL (e.g., https://staging-model-service.example.com).
+# - For production, set the MODEL_SERVICE_URL environment variable to the production service URL (e.g., https://model-service.example.com).
+# Ensure the URL is accurate and accessible from the respective environment.
+MODEL_SERVICE_URL = os.getenv('MODEL_SERVICE_URL', 'http://localhost:5001')  # Default to localhost for development
 APP_VERSION = os.getenv('APP_VERSION', '0.1.0')  # TODO: Dummy version, replace with actual app version
 
 # For local development you can use a .env file

--- a/app-service/requirements.txt
+++ b/app-service/requirements.txt
@@ -1,0 +1,6 @@
+flasgger==0.9.7.1
+Flask==3.1.0
+flask-cors==5.0.1
+gunicorn==23.0.0
+python-dotenv==1.1.0
+requests==2.32.3


### PR DESCRIPTION
Provide the following API endpoints: 

1. **Health Check**
   - Endpoint: `/health`
   - Method: GET
   - Description: Health check endpoint to verify service status
   - Response: 200 - Service is healthy

2. **Version Information**
   - Endpoint: `/version`
   - Method: GET
   - Description: Retrieves version information for app, model service, and lib-version (*TODO*)
   - Response: 200 - Version information

3. **Prediction**
   - Endpoint: `/predict`
   - Method: POST
   - Description: Makes a prediction using the model service (*TODO*)
   - Request: JSON body with `data` field
   - Responses: 
     - 200 - Prediction results
     - 400 - Invalid input
     - 500 - Error making prediction

All API endpoints are documented with Swagger at the `/apidocs/` endpoint.