### PR TITLE
feat: add metrics in backend (a3)

### DIFF
--- a/app-service/requirements.txt
+++ b/app-service/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv==1.1.0
 requests==2.32.3
 git+https://github.com/remla25-team21/lib-version.git
 loguru==0.7.2
+prometheus-client==0.22.0


### PR DESCRIPTION
Three metrics exposed to `/metrics` and `/metrics-info`:

1. **Counter Metric: `sentiment_predictions_total`**
   - Tracks the total number of sentiment predictions made
   - Uses labels to differentiate between positive and negative sentiment predictions

2. **Gauge Metric: `sentiment_positive_ratio`**
   - Measures the ratio of positive to total sentiment predictions (value between 0-1)

3. **Histogram Metric: `sentiment_prediction_latency_seconds`**
   - Measures the response time for sentiment predictions in seconds
   - Uses buckets to categorize response times into ranges (0.05s to 10s)
