### PR TITLE
feat(a5): add 3 CE features for backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ coverage/
 # Environment variables
 .env
 .env.*
+
+*.json

--- a/README.md
+++ b/README.md
@@ -74,3 +74,30 @@ python app.py
 5. **Access the backend API**
 
 The API will be available at [http://localhost:5000](http://localhost:5000) with documentation at [http://localhost:5000/apidocs/](http://localhost:5000/apidocs/)
+
+## 📊 Metrics and Monitoring
+
+The app-service includes built-in Prometheus metrics for monitoring application performance and user behavior. These metrics are particularly useful for observability and measuring the effectiveness of the sentiment analysis model.
+
+### Available Metrics
+
+The following metrics are collected by the app-service:
+
+- **sentiment_predictions_total**: Counter that tracks total predictions by sentiment (positive/negative/unknown)
+- **sentiment_positive_ratio**: Gauge that shows the ratio of positive to total sentiments (0-1)
+- **sentiment_prediction_latency_seconds**: Histogram tracking prediction response times
+- **model_usage_total**: Counter tracking model usage by experiment variant (for A/B testing)
+- **user_session_duration_seconds**: Histogram tracking user session duration
+
+### Accessing Metrics
+
+Metrics can be accessed in two ways:
+
+1. **Prometheus Endpoint**:
+   - Access raw metrics at [http://localhost:5000/metrics](http://localhost:5000/metrics) when running locally
+   - In production, this endpoint is scraped by Prometheus
+
+2. **Metrics Info Endpoint**:
+   - More readable metrics metadata at [http://localhost:5000/metrics-info](http://localhost:5000/metrics-info)
+
+For the full monitoring setup, please refer to the [helm folder in operations repository](https://github.com/remla25-team21/operation/tree/main/kubernetes/helm/sentiment-analysis#prometheus-monitoring).

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The following metrics are collected by the app-service:
 - **sentiment_prediction_latency_seconds**: Histogram tracking prediction response times
 - **model_usage_total**: Counter tracking model usage by experiment variant (for A/B testing)
 - **user_session_duration_seconds**: Histogram tracking user session duration
+- **user_star_ratings**: Histogram tracking distribution of user satisfaction ratings on a 1-5 star scale
 
 ### Accessing Metrics
 

--- a/app-service/config.py
+++ b/app-service/config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from dotenv import load_dotenv
 


### PR DESCRIPTION
Added 3 metrics upon previous PR https://github.com/remla25-team21/app/pull/13:

1. **model_usage_total** (Counter)
   - Tracks the number of times the prediction model is used
   - Essential for measuring feature adoption and comparing variant performance

2. **user_session_duration_seconds** (Histogram)
   - Measures the duration of user sessions in seconds
   - Useful for understanding user engagement patterns

3. **user_star_ratings** (Histogram)
   - Tracks the distribution of user star ratings (1-5 scale)
   - Provides insights into customer satisfaction levels across different restaurants